### PR TITLE
Add new dev2/resave.py with sharding example

### DIFF
--- a/dev2/resave.py
+++ b/dev2/resave.py
@@ -24,6 +24,9 @@ parser.add_argument("output_path")
 ns = parser.parse_args()
 
 
+NGFF_VERSION = "0.5"
+
+
 def create_configs(ns):
     configs = []
     for selection in ("input", "output"):
@@ -130,7 +133,7 @@ def convert_array(input_path: str, output_path: str, dimension_names):
 def convert_image(read_root, input_path, write_root, output_path):
     dimension_names = None
     # top-level version...
-    ome_attrs = {"version": "0.5-dev2"}
+    ome_attrs = {"version": NGFF_VERSION}
     for key, value in read_root.attrs.items():
         # ...replaces all other versions - remove
         if "version" in value:
@@ -202,7 +205,7 @@ if read_root.attrs.get("multiscales"):
 # plate...
 elif read_root.attrs.get("plate"):
 
-    ome_attrs = {"version": "0.5-dev2"}
+    ome_attrs = {"version": NGFF_VERSION}
     for key, value in read_root.attrs.items():
         # ...replaces all other versions - remove
         if "version" in value:
@@ -230,6 +233,7 @@ elif read_root.attrs.get("plate"):
             out_path = os.path.join(ns.output_path, img_path)
             input_path = os.path.join(ns.input_path, img_path)
             print("img_path", img_path)
-            img_v2 = zarr.open_group(store=read_store, path=img_path, zarr_format=2)
+            img_v2 = zarr.open_group(store=STORES[0], path=img_path, zarr_format=2)
+            image_group = write_root.create_group(img_path)
             # print('img_v2', { k:v for (k,v) in img_v2.attrs.items()})
-            convert_image(img_v2, input_path, out_path)
+            convert_image(img_v2, input_path, image_group, out_path)

--- a/dev2/resave.py
+++ b/dev2/resave.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+import numpy as np
+import zarr
+import sys
+import os
+
+import tensorstore as ts
+
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument("input_path")
+parser.add_argument("output_path")
+ns = parser.parse_args()
+
+
+if os.path.exists(ns.output_path):
+    print(f"{ns.output_path} exists. Exiting")
+    sys.exit(1)
+
+
+def convert_array(input_path, output_path):
+    read = ts.open({
+        'driver': 'zarr',
+        'kvstore': {
+            'driver': 'file',
+            'path': input_path,
+        },
+    }).result()
+
+    shape = read.shape
+    chunks = read.schema.chunk_layout.read_chunk.shape
+
+    # bigger_chunk includes 2 of the regular chunks
+    bigger_chunk = list(chunks[:])
+    bigger_chunk[0] = bigger_chunk[0] * 2
+
+    # sharding breaks bigger_chunk down into regular chunks
+    # https://google.github.io/tensorstore/driver/zarr3/index.html#json-driver/zarr3/Codec/sharding_indexed
+    sharding_codec = {
+        "name": "sharding_indexed",
+        "configuration": {
+            "chunk_shape": chunks,
+            "codecs": [{"name": "bytes", "configuration": {"endian": "little"}},
+                       {"name": "gzip", "configuration": {"level": 5}}],
+            "index_codecs": [{"name": "bytes", "configuration": {"endian": "little"}},
+                             {"name": "crc32c"}],
+            "index_location": "end"
+        }
+    }
+
+    codecs = [sharding_codec]
+
+    # Alternative without sharding...
+    # blosc_codec = {"name": "blosc", "configuration": {
+    #     "cname": "lz4", "clevel": 5}}
+    # codecs = [blosc_codec]
+
+    write = ts.open({
+        "driver": "zarr3",
+        "kvstore": {
+            "driver": "file",
+            "path": output_path
+        },
+        "metadata": {
+            "shape": shape,
+            "chunk_grid": {"name": "regular", "configuration": {"chunk_shape": bigger_chunk}},
+            "chunk_key_encoding": {"name": "default"},
+            "codecs": codecs,
+            "data_type": read.dtype,
+        },
+        "create": True,
+    }).result()
+
+    future = write.write(read)
+    future.result()
+
+
+store_class = zarr.store.LocalStore
+if ns.input_path.startswith("http"):
+    # TypeError: Can't instantiate abstract class RemoteStore with abstract methods get_partial_values, list, list_dir, list_prefix, set_partial_values
+    store_class = zarr.store.RemoteStore
+read_store = store_class(ns.input_path, mode="r")
+# Needs zarr_format=2 or we get ValueError("store mode does not support writing")
+read_root = zarr.open_group(store=read_store, zarr_format=2)
+
+# Create new Image...
+write_store = zarr.store.LocalStore(ns.output_path, mode="w")
+root = zarr.Group.create(write_store)
+# top-level version...
+ome_attrs = {"version": "0.5-dev2"}
+for key, value in read_root.attrs.items():
+    # ...replaces all other versions - remove
+    if "version" in value:
+        del (value["version"])
+    if key == "multiscales" and "version" in value[0]:
+        del (value[0]["version"])
+    ome_attrs[key] = value
+# dev2: everything is under 'ome' key
+root.attrs["ome"] = ome_attrs
+
+# convert arrays
+multiscales = read_root.attrs.get("multiscales")
+for ds in multiscales[0]["datasets"]:
+    ds_path = ds["path"]
+    convert_array(
+        os.path.join(ns.input_path, ds_path),
+        os.path.join(ns.output_path, ds_path)
+    )

--- a/dev2/resave.py
+++ b/dev2/resave.py
@@ -72,25 +72,26 @@ def convert_array(input_path: str, output_path: str, dimension_names):
     shape = read.shape
     chunks = read.schema.chunk_layout.read_chunk.shape
 
-    # bigger_chunk includes 2 of the regular chunks
-    bigger_chunk = list(chunks[:])
-    bigger_chunk[0] = bigger_chunk[0] * 2
+    # # bigger_chunk includes 2 of the regular chunks
+    # bigger_chunk = list(chunks[:])
+    # bigger_chunk[0] = bigger_chunk[0] * 2
 
-    # sharding breaks bigger_chunk down into regular chunks
-    # https://google.github.io/tensorstore/driver/zarr3/index.html#json-driver/zarr3/Codec/sharding_indexed
-    sharding_codec = {
-        "name": "sharding_indexed",
-        "configuration": {
-            "chunk_shape": chunks,
-            "codecs": [{"name": "bytes", "configuration": {"endian": "little"}},
-                       {"name": "gzip", "configuration": {"level": 5}}],
-            "index_codecs": [{"name": "bytes", "configuration": {"endian": "little"}},
-                             {"name": "crc32c"}],
-            "index_location": "end"
-        }
-    }
+    # # sharding breaks bigger_chunk down into regular chunks
+    # # https://google.github.io/tensorstore/driver/zarr3/index.html#json-driver/zarr3/Codec/sharding_indexed
+    # sharding_codec = {
+    #     "name": "sharding_indexed",
+    #     "configuration": {
+    #         "chunk_shape": chunks,
+    #         "codecs": [{"name": "bytes", "configuration": {"endian": "little"}},
+    #                    {"name": "gzip", "configuration": {"level": 5}}],
+    #         "index_codecs": [{"name": "bytes", "configuration": {"endian": "little"}},
+    #                          {"name": "crc32c"}],
+    #         "index_location": "end"
+    #     }
+    # }
 
     # codecs = [sharding_codec]
+    # chunks = bigger_chunk
 
     # Alternative without sharding...
     blosc_codec = {"name": "blosc", "configuration": {
@@ -103,7 +104,7 @@ def convert_array(input_path: str, output_path: str, dimension_names):
         "delete_existing": ns.output_overwrite,
         "metadata": {
             "shape": shape,
-            "chunk_grid": {"name": "regular", "configuration": {"chunk_shape": bigger_chunk}},
+            "chunk_grid": {"name": "regular", "configuration": {"chunk_shape": chunks}},
             "chunk_key_encoding": {"name": "default"},
             "codecs": codecs,
             "data_type": read.dtype,
@@ -205,5 +206,4 @@ elif read_root.attrs.get("plate"):
             print("img_path", img_path)
             img_v2 = zarr.open_group(store=read_store, path=img_path, zarr_format=2)
             # print('img_v2', { k:v for (k,v) in img_v2.attrs.items()})
-            print(input_path, out_path)
             convert_image(img_v2, input_path, out_path)

--- a/dev2/resave.py
+++ b/dev2/resave.py
@@ -48,12 +48,12 @@ def convert_array(input_path, output_path, dimension_names):
         }
     }
 
-    codecs = [sharding_codec]
+    # codecs = [sharding_codec]
 
     # Alternative without sharding...
-    # blosc_codec = {"name": "blosc", "configuration": {
-    #     "cname": "lz4", "clevel": 5}}
-    # codecs = [blosc_codec]
+    blosc_codec = {"name": "blosc", "configuration": {
+        "cname": "lz4", "clevel": 5}}
+    codecs = [blosc_codec]
 
     write = ts.open({
         "driver": "zarr3",

--- a/dev2/resave.py
+++ b/dev2/resave.py
@@ -149,7 +149,7 @@ for config, path, mode in (
         (CONFIGS[0], ns.input_path, "r"),
         (CONFIGS[1], ns.output_path, "w")
     ):
-    if config["bucket"]:
+    if "bucket" in config:
         store_class = zarr.store.RemoteStore
         anon = config.get("aws_credentials", {}).get("anonymous", False)
         store = store_class(
@@ -188,7 +188,7 @@ elif read_root.attrs.get("plate"):
     plate_attrs = read_root.attrs.get("plate")
     for well in plate_attrs.get("wells"):
         well_path = well["path"]
-        well_v2 = zarr.open_group(store=read_store, path=well_path, zarr_format=2)
+        well_v2 = zarr.open_group(store=STORES[0], path=well_path, zarr_format=2)
         well_group = write_root.create_group(well_path)
         # well_attrs = { k:v for (k,v) in well_v2.attrs.items()}
         # TODO: do we store 'version' in well?


### PR DESCRIPTION
Sample data generated with this updated `resave.py` can be viewed at https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://minio-dev.openmicroscopy.org/idr/v0.5-dev2/6001240.zarr

Also tried sharding https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://minio-dev.openmicroscopy.org/idr/v0.5-dev2/6001240_sharded.zarr although this ISN'T working for the loading of chunks with zarrita.js