### PR TITLE
example with rembi module

### DIFF
--- a/dev3/2024-07-02/example-metadata/rembi-modules.json
+++ b/dev3/2024-07-02/example-metadata/rembi-modules.json
@@ -1,0 +1,115 @@
+{
+    "@context": [
+        "https://w3id.org/ro/crate/1.1/context",
+        {
+            "organism_classification": "https://schema.org/taxonomicRange",
+            "BioChemEntity": "https://schema.org/BioChemEntity",
+            "channel": "https://w3id.org/reproduceme#Channel",
+            "obo": "http://purl.obolibrary.org/obo/",
+            "FBcv": "http://ontobee.org/ontology/FBcv",
+            "acquisiton_method": {
+                "@reverse": "https://schema.org/result",
+                "@type": "@id"
+            },
+            "biological_entity": "https://schema.org/about",
+            "biosample": "http://purl.obolibrary.org/obo/OBI_0002648",
+            "preparation_method": "https://www.wikidata.org/wiki/Property:P1537",
+            "specimen": "http://purl.obolibrary.org/obo/HSO_0000308"            
+        }
+    ],
+    "@graph": [
+        {
+            "@type": "CreativeWork",
+            "@id": "ro-crate-metadata.json",
+            "conformsTo": {
+                "@id": "https://w3id.org/ro/crate/1.1"
+            },
+            "about": {
+                "@id": "./"
+            }
+        },
+        {
+            "@id": "./",
+            "@type": "Dataset",
+            "name": "Light microscopy photo of a fly",
+            "description": "Light microscopy photo of a fruit fly.",
+            "licence": "https://creativecommons.org/licenses/by/4.0/",
+            "hasPart": {
+                "@id": "./dros-mel-image.zarr/"
+            }
+        },
+        {
+            "@id": "./dros-mel-image.zarr/",
+            "@type": "Dataset",
+            "name": "OME-ZARR files",
+            "description": "the ome zarr files of the fly.",
+            "biosample": [
+                "_b:01"
+            ]
+        },
+        {
+            "@id": "_:b01",
+            "@type": [
+                "biosample"
+            ],
+            "biological_entity": [
+                "_:b2"
+            ]
+        },
+        {
+            "@id": "_:b02",
+            "@type": [
+                "FBcv:0003045"
+            ],
+            "biosample": [
+                "_:b01"
+            ]
+            "preparation_method": [
+                "_:b1"
+            ],
+            "channel": [
+                "_:c1",
+                "_:c2"
+            ]
+        },
+        {
+            "@id": "_:b0",
+            "@type": [
+                "http://purl.obolibrary.org/obo/FBbi_00000243"
+            ],
+            "specimen": [
+                "_:b02"
+            ]
+        },
+        {
+            "@id": "_:b1",
+            "@type": [
+                "obo:OBI_0000272"
+            ],
+            "description": "The fruit flies were individually encased in epoxy resin..."
+        },
+        {
+            "@id": "_:b2",
+            "@type": [
+                "BioChemEntity"
+            ],
+            "organism_classification": "NCBI:txid7227"
+        },
+        {
+            "@id": "_:c1",
+            "@type": [
+                "channel"
+            ],
+            "content": "http://purl.obolibrary.org/obo/MI_1032",
+            "biological_entity": "http://snomed.info/id/312239001"
+        },
+        {
+            "@id": "_:c2",
+            "@type": [
+                "channel"
+            ],
+            "content": "http://purl.obolibrary.org/obo/NCIT_C122989",
+            "biological_entity": "http://purl.obolibrary.org/obo/GO_0005634"
+        }
+    ]
+ }

--- a/dev3/2024-07-02/example-metadata/rembi-modules.json
+++ b/dev3/2024-07-02/example-metadata/rembi-modules.json
@@ -6,7 +6,7 @@
             "BioChemEntity": "https://schema.org/BioChemEntity",
             "channel": "https://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome_xsd.html#Channel",
             "obo": "http://purl.obolibrary.org/obo/",
-            "FBcv": "http://ontobee.org/ontology/FBcv",
+            "FBcv": "http://ontobee.org/ontology/FBcv/",
             "acquisiton_method": {
                 "@reverse": "https://schema.org/result",
                 "@type": "@id"

--- a/dev3/2024-07-02/example-metadata/rembi-modules.json
+++ b/dev3/2024-07-02/example-metadata/rembi-modules.json
@@ -4,7 +4,7 @@
         {
             "organism_classification": "https://schema.org/taxonomicRange",
             "BioChemEntity": "https://schema.org/BioChemEntity",
-            "channel": "https://w3id.org/reproduceme#Channel",
+            "channel": "https://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome_xsd.html#Channel",
             "obo": "http://purl.obolibrary.org/obo/",
             "FBcv": "http://ontobee.org/ontology/FBcv",
             "acquisiton_method": {
@@ -59,7 +59,7 @@
         {
             "@id": "_:b02",
             "@type": [
-                "FBcv:0003045"
+                "FBcv:FBcv_0003405"
             ],
             "biosample": [
                 "_:b01"

--- a/dev3/2024-07-02/example-metadata/rembi-modules.json
+++ b/dev3/2024-07-02/example-metadata/rembi-modules.json
@@ -63,7 +63,7 @@
             ],
             "biosample": [
                 "_:b01"
-            ]
+            ],
             "preparation_method": [
                 "_:b1"
             ],


### PR DESCRIPTION
Here's an example I made. I was wondering from the example [min-specimen-biosample.json](https://github.com/ome/ome2024-ngff-challenge/blob/main/dev3/2024-07-02/example-metadata/min-specimen-biosample.json) if we shouldn't group metadata within REMBI blocks. 

My example is a mess, and I'm not sure what type should be for these REMBI blocks. For the Specimen, I chose for type "Whole organism" from a Drosophila ontology. (the ontobee link is broken, but here's from the [OLS](https://www.ebi.ac.uk/ols4/ontologies/fbcv/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FFBcv_0003045))


* the specimen is linked to a biosample
* the image acquisition is linked to a specimen
* the channels are listed from a specimen 

Screenshot from https://json-ld.org/playground/

![image](https://github.com/user-attachments/assets/178bb3fd-c2be-48f0-aaf6-6d0981d6ba10)

