### PR TITLE
Example ro-crate-metadata generation

### DIFF
--- a/dev3/zarr-crate/README.md
+++ b/dev3/zarr-crate/README.md
@@ -1,0 +1,3 @@
+A small python package/library extending rocrate to make creating ro-crate-metadata.json for ome-zarr easier. See example_usage/create_fly_ro_crate_metadata.py for an example script that creates example_usage/ro-crate-metadata.json.
+
+Currently very much a 'work in progress'

--- a/dev3/zarr-crate/example_usage/create_fly_ro_crate_metadata.py
+++ b/dev3/zarr-crate/example_usage/create_fly_ro_crate_metadata.py
@@ -1,0 +1,29 @@
+import json
+from zarr_crate.zarr_extension import ZarrCrate
+from zarr_crate.rembi_extension import Biosample, Specimen, ImageAcquistion
+
+
+if __name__ == "__main__":
+    crate = ZarrCrate()
+
+    zarr_root = crate.add_dataset(
+        "./",
+        properties={
+            "name": "Light microscopy photo of a fly",
+            "description": "Light microscopy photo of a fruit fly.",
+            "licence": "https://creativecommons.org/licenses/by/4.0/",
+        },
+    )
+    biosample = crate.add(
+        Biosample(crate, properties={"organism_classification": {"@id": "NCBI:txid7227" }})
+    )
+    specimen = crate.add(Specimen(crate, biosample))
+    image_acquisition = crate.add(
+        ImageAcquistion(crate, specimen, properties={"fbbi_id": {"@id": "obo:FBbi_00000243"}})
+    )
+    zarr_root["resultOf"] = image_acquisition
+
+    metadata_dict = crate.metadata.generate()
+
+    with open("ro-crate-metadata.json", "w") as f:
+        f.write(json.dumps(metadata_dict, indent=2))

--- a/dev3/zarr-crate/example_usage/ro-crate-metadata.json
+++ b/dev3/zarr-crate/example_usage/ro-crate-metadata.json
@@ -1,0 +1,66 @@
+{
+  "@context": [
+    "https://w3id.org/ro/crate/1.1/context",
+    {
+      "organism_classification": "https://schema.org/taxonomicRange",
+      "BioChemEntity": "https://schema.org/BioChemEntity",
+      "channel": "https://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome_xsd.html#Channel",
+      "obo": "http://purl.obolibrary.org/obo/",
+      "FBcv": "http://ontobee.org/ontology/FBcv/",
+      "acquisiton_method": {
+        "@reverse": "https://schema.org/result",
+        "@type": "@id"
+      },
+      "biological_entity": "https://schema.org/about",
+      "biosample": "http://purl.obolibrary.org/obo/OBI_0002648",
+      "preparation_method": "https://www.wikidata.org/wiki/Property:P1537",
+      "specimen": "http://purl.obolibrary.org/obo/HSO_0000308"
+    }
+  ],
+  "@graph": [
+    {
+      "@id": "./",
+      "@type": "Dataset",
+      "name": "Light microscopy photo of a fly",
+      "description": "Light microscopy photo of a fruit fly.",
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "resultOf": {
+        "@id": "#7954ed7b-f385-4044-b1e1-bfd5c2cd469a"
+      }
+    },
+    {
+      "@id": "ro-crate-metadata.json",
+      "@type": "CreativeWork",
+      "conformsTo": {
+        "@id": "https://w3id.org/ro/crate/1.1"
+      },
+      "about": {
+        "@id": "./"
+      }
+    },
+    {
+      "@id": "#6b8ce0f2-ae6e-4cca-aee8-3251e5fa5bc0",
+      "@type": "biosample",
+      "organism_classification": {
+        "@id": "NCBI:txid7227"
+      }
+    },
+    {
+      "@id": "#6279dfa3-6ed1-4ce2-8359-07984e3d47fd",
+      "@type": "specimen",
+      "specimen": {
+        "@id": "#6b8ce0f2-ae6e-4cca-aee8-3251e5fa5bc0"
+      }
+    },
+    {
+      "@id": "#7954ed7b-f385-4044-b1e1-bfd5c2cd469a",
+      "@type": "specimen",
+      "fbbi_id": {
+        "@id": "obo:FBbi_00000243"
+      },
+      "specimen": {
+        "@id": "#6279dfa3-6ed1-4ce2-8359-07984e3d47fd"
+      }
+    }
+  ]
+}

--- a/dev3/zarr-crate/pyproject.toml
+++ b/dev3/zarr-crate/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.poetry]
+name = "zarr-crate"
+version = "0.1.0"
+description = "RO-Crate OMEZARR metadata helper"
+authors = ["Francois Sherwood <fsherwood@ebi.ac.uk>"]
+readme = "README.md"
+packages = [{include = "zarr_crate"}]
+
+
+[tool.poetry.dependencies]
+python = "^3.10"
+rocrate = "^0.10"
+
+[tool.poetry.group.dev.dependencies]
+ipython = "^8.22.2"
+pytest = "^7.4.3"
+pytest-mock = "^3.14.0"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/dev3/zarr-crate/zarr_crate/rembi_extension.py
+++ b/dev3/zarr-crate/zarr_crate/rembi_extension.py
@@ -1,0 +1,76 @@
+from rocrate.model.contextentity import ContextEntity
+
+
+class Biosample(ContextEntity):
+    def __init__(self, crate, identifier=None, properties=None):
+        biosample_type_path = "biosample"
+        if properties:
+            biosample_properties = {}
+            biosample_properties.update(properties)
+            if "@type" in properties.keys():
+                biosample_types = biosample_properties["@type"]
+                if biosample_type_path not in biosample_types:
+                    try:
+                        biosample_types.append(biosample_type_path)
+                    except:
+                        biosample_types = [biosample_types]
+                        biosample_types.append(biosample_type_path)
+                    biosample_properties["@type"] = biosample_types
+            else:
+                biosample_properties.update({"@type": biosample_type_path})
+        else:
+            biosample_properties = {"@type": biosample_type_path}
+
+        super().__init__(crate, identifier, biosample_properties)
+
+
+class Specimen(ContextEntity):
+    def __init__(self, crate, biosample, identifier=None, properties=None):
+        specimen_type_path = "specimen"
+        if properties:
+            specimen_properties = {}
+            specimen_properties.update(properties)
+            if "@type" in properties.keys():
+                specimen_type = specimen_properties["@type"]
+                if specimen_type_path not in specimen_type:
+                    try:
+                        specimen_type.append(specimen_type_path)
+                    except:
+                        specimen_type = [specimen_type]
+                        specimen_type.append(specimen_type_path)
+                    specimen_properties["@type"] = specimen_type
+            else:
+                specimen_properties.update({"@type": specimen_type_path})
+        else:
+            specimen_properties = {"@type": specimen_type_path}
+
+        super().__init__(crate, identifier, specimen_properties)
+
+        self["specimen"] = biosample
+
+
+class ImageAcquistion(ContextEntity):
+    def __init__(self, crate, specimen, identifier=None, properties=None):
+        image_acquisition_type_path = "specimen"
+        if properties:
+            image_acquisition_properties = {}
+            image_acquisition_properties.update(properties)
+            if "@type" in properties.keys():
+                image_acquisition_type = image_acquisition_properties["@type"]
+                if image_acquisition_type_path not in image_acquisition_type:
+                    try:
+                        image_acquisition_type.append(image_acquisition_type_path)
+                    except:
+                        image_acquisition_type = [image_acquisition_type]
+                        image_acquisition_type.append(image_acquisition_type_path)
+                    image_acquisition_properties["@type"] = image_acquisition_type
+            else:
+                image_acquisition_properties.update(
+                    {"@type": image_acquisition_type_path}
+                )
+        else:
+            image_acquisition_properties = {"@type": image_acquisition_type_path}
+
+        super().__init__(crate, identifier, image_acquisition_properties)
+
+        self["specimen"] = specimen

--- a/dev3/zarr-crate/zarr_crate/zarr_extension.py
+++ b/dev3/zarr-crate/zarr_crate/zarr_extension.py
@@ -1,0 +1,22 @@
+from rocrate.rocrate import ROCrate
+
+
+class ZarrCrate(ROCrate):
+
+    def __init__(self, source=None, gen_preview=False, init=False, exclude=None):
+        super().__init__(source, gen_preview, init, exclude)
+        self.metadata.extra_terms = {
+            "organism_classification": "https://schema.org/taxonomicRange",
+            "BioChemEntity": "https://schema.org/BioChemEntity",
+            "channel": "https://www.openmicroscopy.org/Schemas/Documentation/Generated/OME-2016-06/ome_xsd.html#Channel",
+            "obo": "http://purl.obolibrary.org/obo/",
+            "FBcv": "http://ontobee.org/ontology/FBcv/",
+            "acquisiton_method": {
+                "@reverse": "https://schema.org/result",
+                "@type": "@id",
+            },
+            "biological_entity": "https://schema.org/about",
+            "biosample": "http://purl.obolibrary.org/obo/OBI_0002648",
+            "preparation_method": "https://www.wikidata.org/wiki/Property:P1537",
+            "specimen": "http://purl.obolibrary.org/obo/HSO_0000308",
+        }


### PR DESCRIPTION
Created example code of how to generate a ro-crate-metadata.json with some REMBI & zarr extensions to generate the context and expected object links.

I wanted to actually use some of the RO Crate tooling to see what it would create in case that helps make decisions about what the metadata would look like / work out what would be easy for us to override/extend to provide to zarr users.