### PR TITLE
Fix sample link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ mc ls -r uk1anon/idr/share/ome2024-ngff-challenge/0.0.5/6001240.zarr/
 
 The dataset can be inspected using a development version of the OME-NGFF
 Validator available at
-<https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/0.0.4/6001240.zarr>
+<https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/0.0.5/6001240.zarr>
 
 ## Converting your data
 


### PR DESCRIPTION
https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/0.0.4/6001240.zarr

in README is wrong - fixed to `0.0.5`.

cc @dominikl 