### PR TITLE
Creator info

### DIFF
--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -9,8 +9,8 @@ import random
 import shutil
 import sys
 import time
-from pathlib import Path
 from importlib.metadata import version as lib_version
+from pathlib import Path
 
 import numpy as np
 import tensorstore as ts
@@ -69,11 +69,8 @@ def strip_version(possible_dict) -> None:
 
 def add_creator(json_dict) -> None:
     # Add _creator - NB: this will overwrite any existing _creator info
-    pkg_version = lib_version('ome2024-ngff-challenge')
-    json_dict["_creator"] = {
-        "name": "ome2024-ngff-challenge",
-        "version": pkg_version
-    }
+    pkg_version = lib_version("ome2024-ngff-challenge")
+    json_dict["_creator"] = {"name": "ome2024-ngff-challenge", "version": pkg_version}
 
 
 class TextBuffer(Buffer):

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -67,6 +67,15 @@ def strip_version(possible_dict) -> None:
         del possible_dict["version"]
 
 
+def add_creator(json_dict) -> None:
+    # Add _creator - NB: this will overwrite any existing _creator info
+    pkg_version = lib_version('ome2024-ngff-challenge')
+    json_dict["_creator"] = {
+        "name": "ome2024-ngff-challenge",
+        "version": pkg_version
+    }
+
+
 class TextBuffer(Buffer):
     """
     Zarr Buffer implementation that simplify saves text at a given location.
@@ -388,11 +397,7 @@ def convert_image(
         ome_attrs[key] = value
 
     # Add _creator - NB: this will overwrite existing _creator info
-    pkg_version = lib_version('ome2024-ngff-challenge')
-    ome_attrs["_creator"] = {
-        "name": "ome2024-ngff-challenge",
-        "version": pkg_version
-    }
+    add_creator(ome_attrs)
 
     if output_config.zr_group is not None:  # otherwise dry-run
         # dev2: everything is under 'ome' key
@@ -567,6 +572,8 @@ def main(ns: argparse.Namespace, rocrate: ROCrateWriter | None = None) -> int:
             # ...replaces all other versions - remove
             strip_version(value)
             ome_attrs[key] = value
+
+        add_creator(ome_attrs)
 
         if output_config.zr_group is not None:  # otherwise dry run
             # dev2: everything is under 'ome' key

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -10,6 +10,7 @@ import shutil
 import sys
 import time
 from pathlib import Path
+from importlib.metadata import version as lib_version
 
 import numpy as np
 import tensorstore as ts
@@ -385,6 +386,13 @@ def convert_image(
             dimension_names = [axis["name"] for axis in value[0]["axes"]]
             strip_version(value[0])
         ome_attrs[key] = value
+
+    # Add _creator - NB: this will overwrite existing _creator info
+    pkg_version = lib_version('ome2024-ngff-challenge')
+    ome_attrs["_creator"] = {
+        "name": "ome2024-ngff-challenge",
+        "version": pkg_version
+    }
 
     if output_config.zr_group is not None:  # otherwise dry-run
         # dev2: everything is under 'ome' key


### PR DESCRIPTION
Fixes #16 

This adds `_creator` info e.g. 

```
"_creator": {
        "name": "ome2024-ngff-challenge",
        "version": "0.0.5.post1.dev0+924ff0a"
      },
```

to `image.zarr/zarr.json` and to `plate.zarr/zarr.json`.


NB: if you have installed `ome2024-ngff-challenge` with `pip install -e .` then the version given above will return the commit at the install time and it doesn't track subsequent commits/branch that you change to.