### PR TITLE
Parallel writing and other fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-dask ">=2024.5.2"
 python = "^3.10"
 rocrate = "^0.10"
 s3fs = ">=2024.6.1"

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -28,6 +28,7 @@ LOGGER = logging.getLogger("resave")
 # Helpers
 #
 
+
 class SafeEncoder(json.JSONEncoder):
     # Handle any TypeErrors so we are safe to use this for logging
     # E.g. dtype obj is not JSON serializable
@@ -36,6 +37,7 @@ class SafeEncoder(json.JSONEncoder):
             return super().default(obj)
         except TypeError:
             return str(obj)
+
 
 def guess_shards(shape: list, chunks: list):
     """
@@ -60,7 +62,7 @@ def csv_int(vstr, sep=",") -> list:
             values.append(v)
         except ValueError as ve:
             raise argparse.ArgumentError(
-                message=f'Invalid value {v0}, values must be a number'
+                message=f"Invalid value {v0}, values must be a number"
             ) from ve
     return values
 
@@ -244,7 +246,9 @@ class Config:
                 else:
                     shutil.rmtree(self.path)
             else:
-                raise Exception(f"{self.path} exists. Use --output-overwrite to overwrite")
+                raise Exception(
+                    f"{self.path} exists. Use --output-overwrite to overwrite"
+                )
 
     def open_group(self):
         # Needs zarr_format=2 or we get ValueError("store mode does not support writing")
@@ -697,8 +701,7 @@ def cli(args=sys.argv[1:]):
     parser.add_argument("--rocrate-organism", type=str)
     parser.add_argument("--rocrate-modality", type=str)
     parser.add_argument("--rocrate-skip", action="store_true")
-    parser.add_argument("--log", default="warn",
-                        help="warn, 'info' or 'debug'")
+    parser.add_argument("--log", default="warn", help="warn, 'info' or 'debug'")
     group_ex = parser.add_mutually_exclusive_group()
     group_ex.add_argument(
         "--output-write-details",

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -397,12 +397,18 @@ def convert_array(
     write_config["create"] = True
     write_config["delete_existing"] = output_config.overwrite
 
-    LOGGER.debug(f"""input_config:
+    LOGGER.log(
+        5,
+        f"""input_config:
 {json.dumps(input_config.ts_config, indent=4)}
-    """)
-    LOGGER.debug(f"""write_config:
+    """,
+    )
+    LOGGER.log(
+        5,
+        f"""write_config:
 {json.dumps(write_config, indent=4, cls=SafeEncoder)}
-    """)
+    """,
+    )
 
     verify_config = base_config.copy()
 
@@ -765,7 +771,9 @@ def cli(args=sys.argv[1:]):
     parser.add_argument("--rocrate-organism", type=str)
     parser.add_argument("--rocrate-modality", type=str)
     parser.add_argument("--rocrate-skip", action="store_true")
-    parser.add_argument("--log", default="warn", help="warn, 'info' or 'debug'")
+    parser.add_argument(
+        "--log", default="warn", help="'error', 'warn', 'info', 'debug' or 'trace'"
+    )
     group_ex = parser.add_mutually_exclusive_group()
     group_ex.add_argument(
         "--output-write-details",
@@ -790,10 +798,17 @@ def cli(args=sys.argv[1:]):
     ns = parser.parse_args(args)
 
     # configure logging
-    numeric_level = getattr(logging, ns.log.upper(), None)
+    if ns.log.upper() == "TRACE":
+        numeric_level = 5
+    else:
+        numeric_level = getattr(logging, ns.log.upper(), None)
     if not isinstance(numeric_level, int):
         raise ValueError(f"Invalid log level: {ns.log}. Use 'info' or 'debug'")
-    logging.basicConfig(level=numeric_level)
+    logging.basicConfig(
+        level=numeric_level,
+        format="%(asctime)s.%(msecs)03d %(levelname)-8s %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
 
     rocrate = None
     if not ns.rocrate_skip:

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -32,11 +32,11 @@ LOGGER = logging.getLogger("resave")
 class SafeEncoder(json.JSONEncoder):
     # Handle any TypeErrors so we are safe to use this for logging
     # E.g. dtype obj is not JSON serializable
-    def default(self, obj):
+    def default(self, o):
         try:
-            return super().default(obj)
+            return super().default(o)
         except TypeError:
-            return str(obj)
+            return str(o)
 
 
 def guess_shards(shape: list, chunks: list):

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -37,6 +37,7 @@ def guess_shards(shape: list, chunks: list):
     ./resave.py input.zarr output.json --output-write-details
     """
     # TODO: hard-coded to return the full size
+    assert chunks is not None  # fixes unused parameter
     return shape
 
 

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -54,14 +54,21 @@ def guess_shards(shape: list, chunks: list):
 
 def chunk_iter(shape: list, chunks: list):
     """
-    Returns a series of tuples, each containing chunck slice
+    Returns a series of tuples, each containing chunk slice
     E.g. for 2D shape/chunks: ((slice(0, 512, 1), slice(0, 512, 1)), (slice(0, 512, 1), slice(512, 1024, 1))...)
     Thanks to Davis Bennett.
     """
-    assert(len(shape) == len(chunks))
+    assert len(shape) == len(chunks)
     chunk_iters = []
     for chunk_size, dim_size in zip(chunks, shape):
-        chunk_tuple = tuple(slice(c_index * chunk_size, min(dim_size, c_index * chunk_size + chunk_size), 1) for c_index in range(-(-dim_size // chunk_size)))
+        chunk_tuple = tuple(
+            slice(
+                c_index * chunk_size,
+                min(dim_size, c_index * chunk_size + chunk_size),
+                1,
+            )
+            for c_index in range(-(-dim_size // chunk_size))
+        )
         chunk_iters.append(chunk_tuple)
     return tuple(product(*chunk_iters))
 

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -422,10 +422,11 @@ def convert_image(
                 # read row by row and overwrite
                 ds_chunks = details[idx]["chunks"]
                 ds_shards = details[idx]["shards"]
-            else:
+            elif not output_script and math.prod(ds_shards) > 100_000_000:
                 # if we're going to convert, let's validate the guess...
-                if not output_script and math.prod(ds_shards) > 100_000_000:
-                    raise ValueError(f"no shard guess: shape={ds_shape}, chunks={ds_chunks}")
+                raise ValueError(
+                    f"no shard guess: shape={ds_shape}, chunks={ds_chunks}"
+                )
 
             if output_script:
                 chunk_txt = ",".join(map(str, ds_chunks))

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -379,7 +379,9 @@ def convert_array(
 
     before = TSMetrics(input_config.ts_config, write_config)
 
-    for slice_tuple in chunk_iter(read.shape, chunks):
+    # read & write a chunk (or shard) at a time:
+    blocks = shards if shards is not None else chunks
+    for slice_tuple in chunk_iter(read.shape, blocks):
         LOGGER.debug(f"array_location: {slice_tuple}")
         future = write[slice_tuple].write(read[slice_tuple])
         future.result()

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -415,18 +415,21 @@ def convert_image(
             with output_config.path.open(mode="w") as o:
                 json.dump(details, o)
         else:
-            if output_chunks and output_shards:
-                ds_chunks = output_chunks
-                ds_shards = output_shards
-            elif output_read_details:
+            if output_read_details:
                 # read row by row and overwrite
                 ds_chunks = details[idx]["chunks"]
                 ds_shards = details[idx]["shards"]
-            elif not output_script and math.prod(ds_shards) > 100_000_000:
-                # if we're going to convert, let's validate the guess...
-                raise ValueError(
-                    f"no shard guess: shape={ds_shape}, chunks={ds_chunks}"
-                )
+            else:
+                if output_chunks:
+                    ds_chunks = output_chunks
+                if output_shards:
+                    ds_shards = output_shards
+                elif not output_script and math.prod(ds_shards) > 100_000_000:
+                    # if we're going to convert, and we guessed the shards,
+                    # let's validate the guess...
+                    raise ValueError(
+                        f"no shard guess: shape={ds_shape}, chunks={ds_chunks}"
+                    )
 
             if output_script:
                 chunk_txt = ",".join(map(str, ds_chunks))


### PR DESCRIPTION
This PR fixes #28 by writing batches of chunks in parallel (based on a configurable number of threads).

---

This also fixes an issue I had when working with larger images:
e.g. https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0047A/4496763.zarr which has shape `4,25,2048,2048`.

I wanted to use `--output-write-details` to generate `parameters.json` using a guess for the shard shape, or even providing a shard shape with `--output-shards 4,1,2048,2048`.
However, in both cases the `guess_shards()` is called and fails since the size is above the threshold:

```
(bf2raw_env) [wmoore@pilot-zarr3-dev ~]$ ome2024-ngff-challenge --input-bucket=idr --input-endpoint=https://uk1s3.embassy.ebi.ac.uk --input-anon zarr/v0.4/idr0047A/4496763.zarr params_4496763.json --output-write-details --output-shards 4,1,2048,2048

Traceback (most recent call last):
  File "/home/wmoore/miniconda3/envs/bf2raw_env/bin/ome2024-ngff-challenge", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/wmoore/miniconda3/envs/bf2raw_env/lib/python3.12/site-packages/ome2024_ngff_challenge/resave.py", line 712, in cli
    converted = main(ns, rocrate)
                ^^^^^^^^^^^^^^^^^
  File "/home/wmoore/miniconda3/envs/bf2raw_env/lib/python3.12/site-packages/ome2024_ngff_challenge/resave.py", line 544, in main
    convert_image(
  File "/home/wmoore/miniconda3/envs/bf2raw_env/lib/python3.12/site-packages/ome2024_ngff_challenge/resave.py", line 406, in convert_image
    ds_shards = guess_shards(ds_shape, ds_chunks)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wmoore/miniconda3/envs/bf2raw_env/lib/python3.12/site-packages/ome2024_ngff_challenge/resave.py", line 42, in guess_shards
    raise ValueError(f"no shard guess: shape={shape}, chunks={chunks}")
```

This PR aims to only perform this validation IF we're actually using the guessed shard_shape to convert an image, NOT if we're just generating `parameters.json`.
Also, we don't validate if the user is doing the conversion with `shard_shape` provided by `--output-shards 4,1,2048,2048` or by `--output-read-details=parameters.json`.


To test...

```
ome2024-ngff-challenge --input-bucket=idr --input-endpoint=https://uk1s3.embassy.ebi.ac.uk --input-anon zarr/v0.4/idr0047A/4496763.zarr params_4496763.json --output-write-details

vi params_4496763.json
# edit each "shards" to: [4, 1, sizeY, sizeX]

ome2024-ngff-challenge --input-bucket=idr --input-endpoint=https://uk1s3.embassy.ebi.ac.uk --input-anon zarr/v0.4/idr0047A/4496763.zarr 4496763.zarr --output-read-details params_4496763.json

```