### PR TITLE
Convert labels to v0.5

### DIFF
--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -23,7 +23,7 @@ from .zarr_crate.rembi_extension import Biosample, ImageAcquistion, Specimen
 from .zarr_crate.zarr_extension import ZarrCrate
 
 NGFF_VERSION = "0.5"
-LOGGER = logging.getLogger("resave")
+LOGGER = logging.getLogger(__file__)
 
 #
 # Helpers
@@ -855,10 +855,11 @@ def cli(args=sys.argv[1:]):
     if not isinstance(numeric_level, int):
         raise ValueError(f"Invalid log level: {ns.log}. Use 'info' or 'debug'")
     logging.basicConfig(
-        level=numeric_level,
+        level=logging.INFO,
         format="%(asctime)s.%(msecs)03d %(levelname)-8s %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
+    LOGGER.setLevel(numeric_level)
 
     rocrate = None
     if not ns.rocrate_skip:

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -570,6 +570,7 @@ def convert_image(
                     output_read_details,
                     output_write_details,
                     output_script,
+                    threads,
                 )
 
 

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -452,17 +452,17 @@ def convert_image(
             LOGGER.debug("No labels group found")
         else:
             labels_attrs = labels_config.zr_attrs.get("labels", [])
-            LOGGER.debug("labels_attrs: %s" % labels_attrs)
+            LOGGER.debug("labels_attrs: %s", labels_attrs)
             labels_output_config = output_config.sub_config("labels")
             labels_output_config.zr_attrs["ome"] = dict(labels_config.zr_attrs)
 
             for label_path in labels_attrs:
                 label_config = labels_config.sub_config(label_path)
-                label_path = Path("labels") / label_path
+                label_path_obj = Path("labels") / label_path
 
                 label_output_config = None
                 if output_config.zr_group is not None:  # otherwise dry-run
-                    label_output_config = output_config.sub_config(label_path)
+                    label_output_config = output_config.sub_config(label_path_obj)
 
                 convert_image(
                     label_config,
@@ -473,6 +473,7 @@ def convert_image(
                     output_write_details,
                     output_script,
                 )
+
 
 class ROCrateWriter:
     def __init__(

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -483,7 +483,11 @@ def convert_image(
         with output_read_details.open() as o:
             details = json.load(o)
     else:
-        details = []  # No resolutions yet
+        details = []
+        if output_config.path.exists() and output_config.path.is_file():
+            # Someone has already written details. Reload them
+            with output_config.path.open() as o:
+                details = json.load(o)
 
     # convert arrays
     multiscales = input_config.zr_attrs.get("multiscales")
@@ -497,9 +501,11 @@ def convert_image(
         if output_write_details:
             details.append(
                 {
-                    "shape": ds_shape,
-                    "chunks": ds_chunks,
-                    "shards": ds_shards,
+                    str(input_config.path / ds_path): {
+                        "shape": ds_shape,
+                        "chunks": ds_chunks,
+                        "shards": ds_shards,
+                    }
                 }
             )
             # Note: not S3 compatible and doesn't use subpath!

--- a/tests/test_resave.py
+++ b/tests/test_resave.py
@@ -147,7 +147,7 @@ def test_remote_simple_with_download(tmp_path):
             IDR_3D,
             str(tmp_path / "out.zarr"),
             "--output-shards=1,10,512,512",
-            "--output-chunks=1,1,256,256"
+            "--output-chunks=1,1,256,256",
         ]
     )
 

--- a/tests/test_resave.py
+++ b/tests/test_resave.py
@@ -138,11 +138,16 @@ def test_remote_hcs_with_scripts(tmp_path):
 
 
 def test_remote_simple_with_download(tmp_path):
+    # The labels for `6001240.zarr` have chunks like [1,59,69,136] which is
+    # not compatible with default shard (whole image, [1,236,275,271]),
+    # so we need to specify both:
     resave.cli(
         [
             *IDR_BUCKET,
             IDR_3D,
             str(tmp_path / "out.zarr"),
+            "--output-shards=1,10,512,512",
+            "--output-chunks=1,1,256,256"
         ]
     )
 


### PR DESCRIPTION
Fixes #19 

NB: we need to specify shards & chunks for the label conversion (making sure that shards/chunks gives whole numbers) since if we don't then it tries to use the input chunks for labels `[1,59,69,136]` and the whole array as shard `[1,236,275,271]` and these are not compatible.

This isn't needed for the image itself, since the chunk shapes for the image are the same as the whole array shape.

Tested on `pilot-zarr3-dev` with
```
(bf2raw_env) [wmoore@pilot-zarr3-dev ~]$ time ome2024-ngff-challenge --input-bucket=idr --input-endpoint=https://uk1s3.embassy.ebi.ac.uk --input-anon zarr/v0.4/idr0062A/6001240.zarr 6001240_labels.zarr --output-shards=1,10,512,512 --output-chunks=1,1,256,256

real	1m9.398s
user	0m17.199s
sys	0m3.408s
```

Uploaded:
```
$ ./mc cp -r 6001240_labels.zarr uk1s3/idr/share/ome2024-ngff-challenge/0.0.5/
```
Available at https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/0.0.5/6001240_labels.zarr

![Screenshot 2024-08-16 at 16 42 09](https://github.com/user-attachments/assets/be5b1a14-04e9-46e3-8fe2-a327d9511b92)
