### PR TITLE
More statistics and conversion notes

### DIFF
--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -140,8 +140,10 @@ def convert_array(
         "elapsed": after.elapsed(),
         "threads": threads,
         "cpu_count": multiprocessing.cpu_count(),
-        "sched_affinity": os.sched_getaffinity(0),
     }
+    if hasattr(os, "sched_getaffinity"):
+        stats["sched_affinity"] = len(os.sched_getaffinity(0))
+
     LOGGER.info(f"""Re-encode (tensorstore) {input_config} to {output_config}
         read: {stats["read"]}
         write: {stats["written"]}

--- a/src/ome2024_ngff_challenge/utils.py
+++ b/src/ome2024_ngff_challenge/utils.py
@@ -122,10 +122,16 @@ def strip_version(possible_dict) -> None:
         del possible_dict["version"]
 
 
-def add_creator(json_dict) -> None:
+def add_creator(json_dict: dict, notes: str | None = None) -> None:
     # Add _creator - NB: this will overwrite any existing _creator info
     pkg_version = lib_version("ome2024-ngff-challenge")
-    json_dict["_creator"] = {"name": "ome2024-ngff-challenge", "version": pkg_version}
+    json_dict["_creator"] = {
+        "name": "ome2024-ngff-challenge",
+        "version": pkg_version,
+        "notes": notes,
+    }
+    if notes:
+        json_dict["_creator"]["notes"] = notes
 
 
 class TextBuffer(Buffer):

--- a/tests/test_resave.py
+++ b/tests/test_resave.py
@@ -182,24 +182,25 @@ def check_bf2raw(tmp_path, input, expected, args):
     [
         pytest.param("2d", 1, [], None),
         pytest.param("2d", 1, ["--output-script"], None),
+        pytest.param("2d", 1, ["--conversion-notes=INFO"], None),
         pytest.param("bf2raw", 2, [], check_bf2raw),
         pytest.param("bf2raw", 2, ["--output-script"], check_bf2raw),
+        pytest.param("bf2raw", 2, ["--conversion-notes=INFO"], check_bf2raw),
         pytest.param("hcs", 8, [], None),
         pytest.param("hcs", 8, ["--output-script"], None),
+        pytest.param("hcs", 8, ["--conversion-notes=INFO"], None),
     ],
 )
 def test_local_tests(tmp_path, input, expected, args, func):
-    assert (
-        dispatch(
-            [
-                "resave",
-                "--cc-by",
-                *args,
-                f"data/{input}.zarr",
-                str(tmp_path / "out.zarr"),
-            ]
-        )
-        == expected
+    converted = dispatch(
+        [
+            "resave",
+            "--cc-by",
+            *args,
+            f"data/{input}.zarr",
+            str(tmp_path / "out.zarr"),
+        ]
     )
+    assert converted == expected
     if func:
         func(tmp_path, input, expected, args)


### PR DESCRIPTION
As discussed during the challenge meeting, a few additional fields would be useful for evaluating. These are now stored (somewhat redundantly) in each stats block. Additionally, a new argument `--conversion-notes` adds text to the _creator field.

This does not yet record memory usage. `psutil` will need adding for cross-platform checks.

see: https://github.com/ome/ome2024-ngff-challenge/pull/31#issuecomment-2302369939