### PR TITLE
Fix s3 writing and test with moto

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ sphinx-autodoc-typehints = { version = "*", optional = true }
 ipython = "^8.22.2"
 pytest = "^7.4.3"
 pytest-mock = "^3.14.0"
-
+moto = {extras = ["s3", "proxy"], version = "^5.0.13"}
 
 [tool.poetry.extras]
 test = ["pytest", "pytest-cov"]

--- a/src/ome2024_ngff_challenge/utils.py
+++ b/src/ome2024_ngff_challenge/utils.py
@@ -309,10 +309,20 @@ class Config:
         )
 
     def check_or_delete_path(self):
-        # If this is local, then delete.
+        # Check remote bucket
         if self.bucket:
-            raise Exception(f"bucket set ({self.bucket}). Refusing to delete.")
+            check = f"s3://{self.bucket}/{self.path / 'zarr.json'}"
+            exists = self.zr_store._fs.exists(check)
+            # https://github.com/getmoto/moto/issues/2964
+            # try:
+            #     exists = bool(self.zr_store._fs.read_text(check))
+            # except FileNotFoundError:
+            #     exists = False
 
+            if exists and not self.overwrite:
+                raise Exception(f"{check} exists. Use --output-overwrite to overwrite")
+
+        # If this is local, then delete.
         if self.path.exists():
             # TODO: This should really be an option on zarr-python
             # as with tensorstore.


### PR DESCRIPTION
@will-moore pointed out that recent changes left the challenge CLI unwilling to resave to s3. This fixes that and attempts to add sufficient testing so that we are confident we aren't clobbering anything without permission.


Note: currently having issues with moto so not yet ready for prime time.