### PR TITLE
Update s3 links in README to remove 0.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,19 +66,20 @@ Other samples:
 
 - [4496763.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/4496763.zarr)
   Shape `4,25,2048,2048`, Size `589.81 MB`, from idr0047.
-- [9822152.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/0.0.5/9822152.zarr)
+- [9822152.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/idr0083/9822152.zarr)
   Shape `1,1,1,93184,144384`, Size `21.57 GB`, from idr0083.
-- [9846151.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/0.0.5/9846151.zarr)
+- [9846151.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/idr0048/9846151.zarr)
   Shape `1,3,1402,5192,2947`, Size `66.04 GB`, from idr0048.
-- [Week9_090907.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/0.0.5/idr0035/Week9_090907.zarr)
+- [Week9_090907.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/idr0035/Week9_090907.zarr)
   plate from idr0035.
 - [l4_sample/color](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://data-humerus.webknossos.org/data/zarr3_experimental/scalable_minds/l4_sample/color)
   from WebKnossos.
 - Plates from idr0090:
-  [190129.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/0.0.5/idr0090/190129.zarr)
+  [190129.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/idr0090/190129.zarr)
   Size `1.0 TB`,
-  [190206.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/0.0.5/idr0090/190206.zarr)
-  Size `485 GB`.
+  [190206.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/idr0090/190206.zarr)
+  Size `485 GB`, [190211.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/idr0090/190211.zarr)
+  Size `704 GB`.
 
  <details><summary>Expand for more details on creation of these samples</summary>
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Other samples:
   [190129.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/idr0090/190129.zarr)
   Size `1.0 TB`,
   [190206.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/idr0090/190206.zarr)
-  Size `485 GB`, [190211.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/idr0090/190211.zarr)
+  Size `485 GB`,
+  [190211.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/idr0090/190211.zarr)
   Size `704 GB`.
 
  <details><summary>Expand for more details on creation of these samples</summary>


### PR DESCRIPTION
Used `mc` to copy data from one location to another to remove `0.0.5` dir incorrectly included in previous links.

E.g.
```
time ./mc cp -r uk1s3/idr/share/ome2024-ngff-challenge/0.0.5/idr0090/190129.zarr uk1s3/idr/share/ome2024-ngff-challenge/idr0090/
...90129.zarr/zarr.json: 1.01 TiB / 1.01 TiB ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓┃ 1.07 GiB/s 16m6s
real    16m6.120s
user    4m27.611s
sys     1m6.473s
```
Once this PR is merged, I can delete data from old locations (might break some links in old PRs etc, especially the validator PR at https://github.com/ome/ome-ngff-validator/pull/36 - so I may update some of those links).

cc @joshmoore 