### PR TITLE
formatting fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,7 @@ repos:
     rev: "v2.2.6"
     hooks:
       - id: codespell
+        args: ["-L crate,Crate"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: "v0.10.0.1"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Other samples:
   Size `485 GB`,
   [190211.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/idr0090/190211.zarr)
   Size `704 GB`.
+- [76-45.zarr](https://deploy-preview-36--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/share/ome2024-ngff-challenge/idr0010/76-45.zarr)
+  plate from idr0010
 
  <details><summary>Expand for more details on creation of these samples</summary>
 


### PR DESCRIPTION
After `pip install pre-commit` and `pre-commit install` I had issues committing with `codespell`

```
...
ruff-format..........................................(no files to check)Skipped
codespell................................................................Failed
- hook id: codespell
- exit code: 65

README.md:197: crate ==> create

shellcheck...........................................(no files to check)Skipped
Disallow improper capitalization.........................................Passed
```

Fixed by ignoring `Crate`.
Also added another sample link (had originally pushed this to #39 but too late)