### PR TITLE
resave main() returns nothing to indicate no error

### DIFF
--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -406,10 +406,10 @@ class ROCrateWriter:
         config.zr_write_text(filename, text)
 
 
-def main(ns: argparse.Namespace) -> int:
+def main(ns: argparse.Namespace) -> int | None:
     """
-    If no images are converted, raises
-    SystemExit. Otherwise, return the number of images.
+    If no images are converted, raises SystemExit.
+    Otherwise, return the number of images, unless --silent.
     """
 
     converted: int = 0
@@ -550,6 +550,11 @@ def main(ns: argparse.Namespace) -> int:
 
     if converted == 0:
         raise SystemExit(1)
+
+    # Support for nextflow etc where response is interpreted as an error.
+    if ns.silent:
+        return None
+
     return converted
 
 
@@ -675,6 +680,7 @@ ADVANCED
         default=16,
         help="number of simultaneous write threads",
     )
+    parser.add_argument("--silent", action="store_true", help="Command returns nothing")
 
     # Very recommended metadata (SHOULD!)
     def license_action(group, arg: str, url: str, recommended: bool = True):

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -406,10 +406,9 @@ class ROCrateWriter:
         config.zr_write_text(filename, text)
 
 
-def main(ns: argparse.Namespace) -> int:
+def main(ns: argparse.Namespace) -> None:
     """
-    If no images are converted, raises
-    SystemExit. Otherwise, return the number of images.
+    If no images are converted, raises SystemExit.
     """
 
     converted: int = 0
@@ -550,7 +549,6 @@ def main(ns: argparse.Namespace) -> int:
 
     if converted == 0:
         raise SystemExit(1)
-    return converted
 
 
 def cli(subparsers: argparse._SubParsersAction):

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -680,7 +680,11 @@ ADVANCED
         default=16,
         help="number of simultaneous write threads",
     )
-    parser.add_argument("--silent", action="store_true", help="Command returns nothing; required for nextflow")
+    parser.add_argument(
+        "--silent",
+        action="store_true",
+        help="Command returns nothing; required for nextflow",
+    )
 
     # Very recommended metadata (SHOULD!)
     def license_action(group, arg: str, url: str, recommended: bool = True):

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -680,7 +680,7 @@ ADVANCED
         default=16,
         help="number of simultaneous write threads",
     )
-    parser.add_argument("--silent", action="store_true", help="Command returns nothing")
+    parser.add_argument("--silent", action="store_true", help="Command returns nothing; required for nextflow")
 
     # Very recommended metadata (SHOULD!)
     def license_action(group, arg: str, url: str, recommended: bool = True):

--- a/src/ome2024_ngff_challenge/resave.py
+++ b/src/ome2024_ngff_challenge/resave.py
@@ -406,9 +406,10 @@ class ROCrateWriter:
         config.zr_write_text(filename, text)
 
 
-def main(ns: argparse.Namespace) -> None:
+def main(ns: argparse.Namespace) -> int:
     """
-    If no images are converted, raises SystemExit.
+    If no images are converted, raises
+    SystemExit. Otherwise, return the number of images.
     """
 
     converted: int = 0
@@ -549,6 +550,7 @@ def main(ns: argparse.Namespace) -> None:
 
     if converted == 0:
         raise SystemExit(1)
+    return converted
 
 
 def cli(subparsers: argparse._SubParsersAction):


### PR DESCRIPTION
Trying to run `resave` using nextflow. Although the conversion appears successful, nextflow thinks there's an error because a non-zero value is returned from the `main()` function that is called by `resave` command.

This updates `main` to return nothing.

<details><summary>Nextflow output</summary>

```
$ ../nextflow run --input idr0054_images.tsv --column 1 --idrId idr0054 --modality "NCIT_C182027" --organism NCBI:txid9606 --name "idr0054" --shards "1,1,1,3072,3072" --chunks "1,1,1,1024,1024" resave.nf

 N E X T F L O W   ~  version 24.04.4

Launching `resave.nf` [irreverent_sammet] DSL2 - revision: 6bfda73597

executor >  local (3)
[41/550457] process > convert (2) [  0%] 0 of 3
executor >  local (3)
[41/550457] process > convert (2) [100%] 1 of 1, failed: 1
[-        ] process > upload      -
[-        ] process > remove      -
ERROR ~ Error executing process > 'convert (3)'

Caused by:
  Process `convert (3)` terminated with an error exit status (1)


Command executed:

  ome2024-ngff-challenge resave --input-bucket=bia-integrator-data --input-endpoint=https://uk1s3.embassy.ebi.ac.uk --input-anon "S-BIAD800/f49ada41-43bf-47ff-99b9-bdf8cc311ce3/f49ada41-43bf-47ff-99b9-bdf8cc311ce3.zarr" "Tonsil 3.zarr" --log error --rocrate-modality=NCIT_C182027 --rocrate-organism=NCBI:txid9606 --rocrate-name=idr0054 --cc-by --output-shards=1,1,1,3072,3072 --output-chunks=1,1,1,1024,1024

Command exit status:
  1

Command output:
  (empty)

Command error:
  
  i:   0%|                                                  | 0/1 [00:00<?, ?it/s]
  i: 100%|██████████████████████████████████████████| 1/1 [00:17<00:00, 17.39s/it]
                                                                                  

Work dir:
  /data/will/nextflow/8f/3e62b617851ce93d3446e384f9b0cb

Tip: you can try to figure out what's wrong by changing to the process work dir and showing the script file named `.command.sh`

 -- Check '.nextflow.log' file for details
```
</details>