### PR TITLE
Darkmode css fixes

### DIFF
--- a/ome2024-ngff-challenge/src/ImageList.svelte
+++ b/ome2024-ngff-challenge/src/ImageList.svelte
@@ -59,6 +59,7 @@
     margin: auto;
     flex: auto 1 1;
     overflow: hidden;
+    background-color: var(--background-color);
   }
 
   .row {

--- a/ome2024-ngff-challenge/src/app.css
+++ b/ome2024-ngff-challenge/src/app.css
@@ -14,7 +14,6 @@
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;

--- a/ome2024-ngff-challenge/src/app.css
+++ b/ome2024-ngff-challenge/src/app.css
@@ -64,6 +64,7 @@ body {
     --bg-opacity: 0;
     background: black;
     color: #bbb;
+    --background-color: #222;
     --light-background: #222;
     --border-color: #333;
     --selected-background: #444;


### PR DESCRIPTION
Darkmode fixes:

To test, use dark mode (with netlify preview below):
 - make your screen small enough to require scrolling the About page. Scroll the page and check for bug seen at https://github.com/ome/ome2024-ngff-challenge/pull/74#issuecomment-2441103148
 - List items now not white background

Before:

![Screenshot 2024-10-28 at 12 13 32](https://github.com/user-attachments/assets/ddfe19fd-acc2-4c09-9785-4e9ee9ae8714)

After:

![Screenshot 2024-10-28 at 12 14 29](https://github.com/user-attachments/assets/0f608b11-dd8c-41d6-b344-64ed575bf1b8)

