### PR TITLE
Use released version of ome-ngff-validator

### DIFF
--- a/ome2024-ngff-challenge/src/ZarrListItem.svelte
+++ b/ome2024-ngff-challenge/src/ZarrListItem.svelte
@@ -104,7 +104,7 @@
     <div>
       Open in <a
       title="Open in Validator: {rowData.url}"
-      href="https://will-moore.github.io/ome-ngff-validator/?source={rowData.url}"
+      href="https://ome.github.io/ome-ngff-validator/?source={rowData.url}"
       target="_blank"
       >OME-Validator.
     </a>


### PR DESCRIPTION
Since https://github.com/ome/ome-ngff-validator/pull/36 is now merged, updating to use released version of validator...