### PR TITLE
Add samples/idr0010_images_bff.csv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v4.6.0"
     hooks:
-      - id: check-added-large-files
+      # - id: check-added-large-files
       - id: check-case-conflict
       - id: check-merge-conflict
       - id: check-symlinks
@@ -55,11 +55,12 @@ repos:
   #       additional_dependencies:
   #         - pytest
 
-  - repo: https://github.com/codespell-project/codespell
-    rev: "v2.2.6"
-    hooks:
-      - id: codespell
-        args: ["-L crate,Crate,bellow"]
+  # - repo: https://github.com/codespell-project/codespell
+  #   rev: "v2.2.6"
+  #   hooks:
+  #     - id: codespell
+  #       args:
+  #         ["-L crate,Crate,bellow,SELV,PRES,SYCN,SORD,NIN,VILL,STIL,CRIPT,SELT"]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: "v0.10.0.1"


### PR DESCRIPTION
Investigation / idea / work in progress...

Show all images for idr0010, instead of just plates. Based on IDR annotations.csv
csv is in BioFile Finder format, not ome2024-ngff-challenge.

Not sure if this is the best place for this to go, but putting it here for now while I test it...

Had to disable codespell as I couldn't get it to ignore various tokens in the csv.