### PR TITLE
Fix build ci syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You can example the contents of a sample dataset by using
 [the minio client](https://github.com/minio/mc):
 
 ```
-$ mc config host add uk1anon https://uk1s3.embassy.ebi.ac.uk "" ""
+$ mc alias set uk1anon https://uk1s3.embassy.ebi.ac.uk "" ""
 Added `uk1anon` successfully.
 $ mc ls -r uk1anon/idr/share/ome2024-ngff-challenge/0.0.5/6001240.zarr/
 [2024-08-01 14:24:35 CEST]  24MiB STANDARD 0/c/0/0/0/0

--- a/ome2024-ngff-challenge/src/ontologyStore.js
+++ b/ome2024-ngff-challenge/src/ontologyStore.js
@@ -10,36 +10,36 @@ class OntologyMetadataField {
     let numericId = "";
     let ontologyId = "";
 
-    if (termId.includes("NCBITaxon") | termId.includes("NCBI:txid")){
+    if (termId.includes("NCBITaxon") | termId.includes("NCBI:txid")) {
       numericId = termId.replace("NCBI:txid", "");
       // cleanup variation
       numericId = numericId.replace("obo:NCBITaxon_", "");
       ontologyId = "NCBITaxon";
-    };
-    
+    }
+
     if (termId.includes("FBbi")) {
       numericId = termId.replace("obo:FBbi_", "");
       //cleanup variations like
       numericId = numericId.replace("obo:FBbi:", "");
       numericId = numericId.replace("FBbi:", "");
       ontologyId = "FBbi";
-    };
-    
+    }
+
     // Other ontologies have been used in the FBBI ID field, e.g. NCIT, OBI or MI
-    if (termId.includes("NCIT_")){
+    if (termId.includes("NCIT_")) {
       numericId = termId.replace("NCIT_", "");
       ontologyId = "NCIT";
-    };
+    }
 
-    if (termId.includes("obo:MI_")){
+    if (termId.includes("obo:MI_")) {
       numericId = termId.replace("obo:MI_", "");
       ontologyId = "MI";
-    };
+    }
 
-    if (termId.includes("obo:OBI_")){
+    if (termId.includes("obo:OBI_")) {
       numericId = termId.replace("obo:OBI_", "");
       ontologyId = "OBI";
-    };
+    }
 
     let curie = ontologyId + "_" + numericId;
     let lowerCaseOntologyId = ontologyId.toLowerCase();


### PR DESCRIPTION
This is on top of #102 .

It fixes the syntax error failures observed in this repo.

I think this is useful although the downstream tests are still failing with 

```
ValueError: Error parsing object member "kvstore": Error parsing object member "aws_credentials"
```

which I do not know how to fix.